### PR TITLE
Keep user logged with posting key

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,9 @@
 </template>
 
 <script>
+import { mapActions } from 'vuex';
 import { isChromeExtension } from '@/helpers/utils';
+import { jsonParse } from './helpers/utils';
 
 const LOADING_ICON_TIMEOUT = 300;
 
@@ -27,20 +29,25 @@ export default {
       return isChromeExtension();
     },
   },
-  created() {
+  methods: mapActions(['login']),
+  async created () {
     const loadingTimeout = setTimeout(() => {
       this.showLoading = true;
     }, LOADING_ICON_TIMEOUT);
 
+    const unlocked = jsonParse(localStorage.getItem('steemconnect_unlocked'));
+    const lastUsername = localStorage.getItem('steemconnect_last_username');
+    if (lastUsername && unlocked[lastUsername]) {
+      await this.login({ username: lastUsername, keys: unlocked[lastUsername] });
+    }
+
     this.$store.dispatch('getDynamicGlobalProperties').then(() => {
       clearTimeout(loadingTimeout);
-
       this.showLoading = false;
     });
   },
   beforeUpdate() {
     if (this.initialized) return;
-
     this.initialized = true;
   },
 };

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -4,6 +4,7 @@ import client from '@/helpers/client';
 import { credentialsValid, privateKeyFrom } from '@/helpers/auth';
 import router from '@/router';
 import { idleDetector } from '@/main';
+import { jsonParse } from '../../helpers/utils';
 
 const state = {
   username: null,
@@ -38,6 +39,13 @@ const actions = {
 
     const result = await client.database.getAccounts([username]);
     commit('login', { result: result[0], keys });
+
+    localStorage.setItem('steemconnect_last_username', username);
+    if (keys.posting) {
+      const unlocked = jsonParse(localStorage.getItem('steemconnect_unlocked')) || {};
+      unlocked[username] = { posting: keys.posting };
+      localStorage.setItem('steemconnect_unlocked', JSON.stringify(unlocked));
+    }
 
     idleDetector.start(rootState.settings.timeout * 60 * 1000, () => {
       idleDetector.stop();


### PR DESCRIPTION
TODO

- [ ] Add checkbox "Remember me" on login page with tooltip
- [ ] Display logged user on the interface
- [ ] Add a way to logout and clear posting keys on localStorage
- [ ] Make it possible to switch account
- [ ] Remember posting key only on website